### PR TITLE
Enhance Prayer Group Searching

### DIFF
--- a/PrayerAppServices/SQL/search_prayer_groups_by_name.sql
+++ b/PrayerAppServices/SQL/search_prayer_groups_by_name.sql
@@ -23,7 +23,8 @@ BEGIN
     LEFT JOIN 
         media_files f ON f.id = g.image_file_id
     WHERE 
-        to_tsvector(g.group_name) @@ websearch_to_tsquery(name_query)
+        to_tsvector(g.group_name) @@ websearch_to_tsquery(lang, name_query)
+        OR g.group_name ILIKE '%' || name_query || '%'
     LIMIT max_num_results;
     RETURN;
 END;

--- a/PrayerAppServices/SQL/search_prayer_groups_by_name.sql
+++ b/PrayerAppServices/SQL/search_prayer_groups_by_name.sql
@@ -23,7 +23,7 @@ BEGIN
     LEFT JOIN 
         media_files f ON f.id = g.image_file_id
     WHERE 
-        to_tsvector(g.group_name) @@ websearch_to_tsquery(lang, name_query)
+        to_tsvector(g.group_name) @@ websearch_to_tsquery(name_query)
         OR g.group_name ILIKE '%' || name_query || '%'
     LIMIT max_num_results;
     RETURN;


### PR DESCRIPTION
* Currently, the Prayer Group Search Route does not handle partial matches well
* This will improve partial matching, such as searching for "Prayer Group" will now return "Prayer Group 1"